### PR TITLE
Improve playlist recipes and add new variants

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,12 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Check formatting
         run: test -z "$(gofmt -l $(git ls-files '*.go'))"
@@ -42,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,35 @@ permissions:
   packages: write
 
 jobs:
-  docker:
+  quality:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l $(git ls-files '*.go'))"
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race ./...
+
+  docker:
+    needs: quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -45,5 +69,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish Docker Image
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -34,6 +37,7 @@ jobs:
         run: go test -race ./...
 
   docker:
+    if: github.event_name != 'pull_request'
     needs: quality
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY go.mod ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o /out/smart-playlist ./cmd/app
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/smart-playlist ./cmd/app
 
 FROM alpine:3.21
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Lightweight Go microservice for Navidrome that generates smart playlists from li
 ## Features
 
 - Fetches the full music library from Navidrome and builds an in-memory track dataset
-- Generates smart playlists with simple scoring logic
+- Generates smart playlists with recipe-specific eligibility, scoring, rotation, and diversity rules
 - Includes built-in playlists:
   - `Discover Weekly`
   - `Rediscover`
@@ -23,13 +23,38 @@ Lightweight Go microservice for Navidrome that generates smart playlists from li
   - `Comfort Shuffle`
   - `More Like Hidden Gems`
   - `Artist Adjacent Comfort`
+  - `Fresh & Unplayed`
+  - `Forgotten Favorites`
+  - `Rising This Week`
+  - `Deep Cuts`
+  - `Quick Mix`
+  - `Longform`
 - Persists a tiny local state cache to improve future recommendations
 - Uses derived features and lightweight vector similarity for better ranking
 - Applies diversity rules with caps per artist and album
+- Applies playlist-specific eligibility rules so each playlist keeps its intended meaning
+- Uses deterministic weekly variation to rotate discovery and shuffle playlists
+- Uses genre matches when available and duration metadata for session-length playlists
 - Creates missing playlists and updates existing ones
 - Runs once on startup, then every 7 days
-- Supports `DRY_RUN=true` to preview playlists without writing changes
 - Uses only the Go standard library
+
+## Playlist Catalog
+
+- `Discover Weekly`: low-play, unplayed, or recently added tracks with weekly rotation
+- `Rediscover`: tracks played before, but not during the last 45 days
+- `Top This Month`: tracks played during the last 31 days, weighted toward rising play counts
+- `Hidden Gems`: low-play tracks, plus highly rated or starred exceptions
+- `Long Time No See`: previously played tracks absent for at least 120 days
+- `Comfort Shuffle`: familiar favorites with stronger weekly variation
+- `More Like Hidden Gems`: behaviorally and genre-adjacent tracks, excluding every source track
+- `Artist Adjacent Comfort`: comfort-adjacent tracks from different artists
+- `Fresh & Unplayed`: tracks added during the last 180 days and never played
+- `Forgotten Favorites`: starred, highly rated, or historically popular tracks absent for at least 180 days
+- `Rising This Week`: tracks with new plays during the current collection interval and activity in the last 14 days
+- `Deep Cuts`: low-play tracks from artists with strong listening history
+- `Quick Mix`: tracks no longer than four minutes
+- `Longform`: tracks at least eight minutes long
 
 ## Project Layout
 
@@ -64,7 +89,6 @@ Optional:
 
 - `PLAYLIST_SIZE` default: `50`
 - `ALBUM_PAGE_SIZE` default: `200`
-- `DRY_RUN` default: `false`
 - `RUN_TIMEOUT` default: `15m`
 - `SCORE_WEIGHT_PLAYCOUNT` default: `1.0`
 - `SCORE_WEIGHT_RECENCY` default: `2.0`
@@ -166,7 +190,6 @@ services:
       NAVIDROME_USER: alice
       NAVIDROME_PASSWORD: alice-password
       PLAYLIST_SIZE: "50"
-      DRY_RUN: "false"
       ENABLE_STATE_CACHE: "true"
       STATE_FILE: /data/smart-playlist/alice/state.json
     volumes:
@@ -181,7 +204,6 @@ services:
       NAVIDROME_USER: bob
       NAVIDROME_PASSWORD: bob-password
       PLAYLIST_SIZE: "50"
-      DRY_RUN: "false"
       ENABLE_STATE_CACHE: "true"
       STATE_FILE: /data/smart-playlist/bob/state.json
     volumes:
@@ -189,19 +211,6 @@ services:
 ```
 
 This avoids cache collisions because each user writes to a different JSON state file. Playlist names can stay the same because they are created under different Navidrome user accounts.
-
-
-```
-
-## Dry Run
-
-To preview generated playlists without modifying Navidrome:
-
-```
-DRY_RUN=true NAVIDROME_URL=http://192.168.0.25:4533 NAVIDROME_USER=user-name NAVIDROME_PASSWORD=your-password go run ./cmd/app
-```
-
-This logs playlist names and track IDs instead of creating or updating playlists.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,51 @@ Optional:
 - `STATE_DIR` optional alternative to `STATE_FILE`
 - `MIN_CANDIDATE_BACKFILL` default: `20`
 
+### Recommendation Weight Tuning
+
+The score weights provide coarse global tuning for playlists that use the shared base score:
+
+- `SCORE_WEIGHT_PLAYCOUNT`: increase to favor familiar and frequently played tracks; decrease to favor exploration
+- `SCORE_WEIGHT_RECENCY`: increase to favor tracks played recently
+- `SCORE_WEIGHT_FRESHNESS`: increase to favor tracks added to the library recently
+- `SCORE_DECAY_DAYS`: controls how long recency and freshness remain influential; larger values create a wider time window
+
+All weight values must be finite and non-negative. `SCORE_DECAY_DAYS` must be positive. The signals multiplied by these weights are normalized, so changing a weight has a predictable bounded effect.
+
+Balanced defaults:
+
+```yaml
+environment:
+  SCORE_WEIGHT_PLAYCOUNT: "1.0"
+  SCORE_WEIGHT_RECENCY: "2.0"
+  SCORE_WEIGHT_FRESHNESS: "1.5"
+  SCORE_DECAY_DAYS: "45"
+```
+
+More discovery and recently added music:
+
+```yaml
+environment:
+  SCORE_WEIGHT_PLAYCOUNT: "0.5"
+  SCORE_WEIGHT_RECENCY: "1.2"
+  SCORE_WEIGHT_FRESHNESS: "2.2"
+  SCORE_DECAY_DAYS: "60"
+```
+
+More familiar and recently played music:
+
+```yaml
+environment:
+  SCORE_WEIGHT_PLAYCOUNT: "1.7"
+  SCORE_WEIGHT_RECENCY: "2.3"
+  SCORE_WEIGHT_FRESHNESS: "0.8"
+  SCORE_DECAY_DAYS: "60"
+```
+
+These settings affect the original recommendation playlists, similarity playlists, `Quick Mix`, and `Longform`. They do not change the dedicated formulas or eligibility rules for `Fresh & Unplayed`, `Forgotten Favorites`, `Rising This Week`, or `Deep Cuts`.
+
+Keep `ENABLE_STATE_CACHE=true` for useful play-count deltas, stability, and playlist history. Evaluate a tuning change over at least two generation cycles because the first run has no previous snapshot. Each run writes the newly generated playlists to Navidrome.
+
 ## Installation
 
 Clone the repository and build it locally:

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	client := navidrome.NewClient(cfg, logger)
 	trackCollector := collector.NewWithPageSize(client, cfg.AlbumPageSize, logger)
-	writer := playlist.NewWriter(client, logger, cfg.DryRun)
+	writer := playlist.NewWriter(client, logger, cfg.Username)
 	generator := playlist.NewGenerator(cfg, logger)
 	featureBuilder := features.NewBuilder(logger)
 	stateStore := state.NewStore(cfg.StateFile, cfg.EnableState, logger)
@@ -138,6 +138,7 @@ func buildHistoryState(
 				RecencyTrend:        item.RecencyTrendScore,
 				RepeatFatigue:       item.RepeatFatigueScore,
 				ArtistSaturation:    item.ArtistSaturation,
+				ArtistAffinity:      item.ArtistAffinity,
 				AlbumSaturation:     item.AlbumSaturation,
 				NoveltyScore:        item.NoveltyScore,
 				StabilityScore:      item.StabilityScore,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       NAVIDROME_USER: your-user
       NAVIDROME_PASSWORD: your-password
       PLAYLIST_SIZE: "50"
-      DRY_RUN: "false"
       ENABLE_STATE_CACHE: "true"
       STATE_FILE: /data/smart-playlist/your-user/state.json
     volumes:

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -82,6 +82,8 @@ func normalizeTrack(input navidrome.TrackPayload) model.Track {
 		Title:      safeString(input.Title, "Unknown Title"),
 		Artist:     safeString(input.Artist, "Unknown Artist"),
 		Album:      safeString(input.Album, "Unknown Album"),
+		Genre:      strings.TrimSpace(input.Genre),
+		Duration:   max(input.Duration, 0),
 		PlayCount:  max(input.PlayCount, 0),
 		LastPlayed: parseTime(input.Played),
 		Created:    parseTime(input.Created),

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1,0 +1,29 @@
+package collector
+
+import (
+	"testing"
+
+	"go-navi-smart-playlist/internal/navidrome"
+)
+
+func TestNormalizeTrackIncludesPlaylistMetadata(t *testing.T) {
+	track := normalizeTrack(navidrome.TrackPayload{
+		ID:       "track-1",
+		Title:    " Title ",
+		Artist:   " Artist ",
+		Album:    " Album ",
+		Genre:    " Jazz ",
+		Duration: 612,
+	})
+
+	if track.Genre != "Jazz" || track.Duration != 612 {
+		t.Fatalf("metadata not normalized: %+v", track)
+	}
+}
+
+func TestNormalizeTrackClampsInvalidNumericMetadata(t *testing.T) {
+	track := normalizeTrack(navidrome.TrackPayload{ID: "track-1", Duration: -20, PlayCount: -3})
+	if track.Duration != 0 || track.PlayCount != 0 {
+		t.Fatalf("numeric metadata not clamped: %+v", track)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,9 @@ package config
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -27,7 +29,6 @@ type Config struct {
 	Password      string
 	PlaylistSize  int
 	AlbumPageSize int
-	DryRun        bool
 	Weights       Weights
 	RunTimeout    time.Duration
 	ClientName    string
@@ -45,24 +46,60 @@ type Weights struct {
 }
 
 func Load() (Config, error) {
+	playlistSize, err := getInt("PLAYLIST_SIZE", defaultPlaylistSize)
+	if err != nil {
+		return Config{}, err
+	}
+	albumPageSize, err := getInt("ALBUM_PAGE_SIZE", defaultAlbumPageSize)
+	if err != nil {
+		return Config{}, err
+	}
+	runTimeout, err := getDuration("RUN_TIMEOUT", defaultRunTimeout)
+	if err != nil {
+		return Config{}, err
+	}
+	enableState, err := getBool("ENABLE_STATE_CACHE", true)
+	if err != nil {
+		return Config{}, err
+	}
+	minBackfill, err := getInt("MIN_CANDIDATE_BACKFILL", defaultBackfillSize)
+	if err != nil {
+		return Config{}, err
+	}
+	playCountWeight, err := getFloat("SCORE_WEIGHT_PLAYCOUNT", 1.0)
+	if err != nil {
+		return Config{}, err
+	}
+	recencyWeight, err := getFloat("SCORE_WEIGHT_RECENCY", 2.0)
+	if err != nil {
+		return Config{}, err
+	}
+	freshnessWeight, err := getFloat("SCORE_WEIGHT_FRESHNESS", 1.5)
+	if err != nil {
+		return Config{}, err
+	}
+	decayDays, err := getFloat("SCORE_DECAY_DAYS", defaultDecayDays)
+	if err != nil {
+		return Config{}, err
+	}
+
 	cfg := Config{
 		BaseURL:       strings.TrimRight(strings.TrimSpace(os.Getenv("NAVIDROME_URL")), "/"),
 		Username:      strings.TrimSpace(os.Getenv("NAVIDROME_USER")),
 		Password:      os.Getenv("NAVIDROME_PASSWORD"),
-		PlaylistSize:  getInt("PLAYLIST_SIZE", defaultPlaylistSize),
-		AlbumPageSize: getInt("ALBUM_PAGE_SIZE", defaultAlbumPageSize),
-		DryRun:        getBool("DRY_RUN", false),
-		RunTimeout:    getDuration("RUN_TIMEOUT", defaultRunTimeout),
+		PlaylistSize:  playlistSize,
+		AlbumPageSize: albumPageSize,
+		RunTimeout:    runTimeout,
 		ClientName:    getString("SUBSONIC_CLIENT_NAME", defaultClientName),
 		APIVersion:    getString("SUBSONIC_API_VERSION", defaultAPIVersion),
 		StateFile:     resolveStateFile(),
-		EnableState:   getBool("ENABLE_STATE_CACHE", true),
-		MinBackfill:   getInt("MIN_CANDIDATE_BACKFILL", defaultBackfillSize),
+		EnableState:   enableState,
+		MinBackfill:   minBackfill,
 		Weights: Weights{
-			PlayCount: getFloat("SCORE_WEIGHT_PLAYCOUNT", 1.0),
-			Recency:   getFloat("SCORE_WEIGHT_RECENCY", 2.0),
-			Freshness: getFloat("SCORE_WEIGHT_FRESHNESS", 1.5),
-			DecayDays: getFloat("SCORE_DECAY_DAYS", defaultDecayDays),
+			PlayCount: playCountWeight,
+			Recency:   recencyWeight,
+			Freshness: freshnessWeight,
+			DecayDays: decayDays,
 		},
 	}
 
@@ -80,6 +117,12 @@ func Load() (Config, error) {
 
 	if cfg.Weights.DecayDays <= 0 {
 		return Config{}, fmt.Errorf("SCORE_DECAY_DAYS must be positive, got %.2f", cfg.Weights.DecayDays)
+	}
+	if cfg.Weights.PlayCount < 0 || cfg.Weights.Recency < 0 || cfg.Weights.Freshness < 0 {
+		return Config{}, errors.New("score weights must be non-negative")
+	}
+	if cfg.RunTimeout <= 0 {
+		return Config{}, fmt.Errorf("RUN_TIMEOUT must be positive, got %s", cfg.RunTimeout)
 	}
 
 	if cfg.MinBackfill < 0 {
@@ -100,7 +143,7 @@ func resolveStateFile() string {
 		stateDir = defaultStateDir
 	}
 
-	return stateDir + "/" + defaultStateFileName
+	return filepath.Join(stateDir, defaultStateFileName)
 }
 
 func getString(key, fallback string) string {
@@ -112,58 +155,61 @@ func getString(key, fallback string) string {
 	return value
 }
 
-func getInt(key string, fallback int) int {
+func getInt(key string, fallback int) (int, error) {
 	value := strings.TrimSpace(os.Getenv(key))
 	if value == "" {
-		return fallback
+		return fallback, nil
 	}
 
 	parsed, err := strconv.Atoi(value)
 	if err != nil {
-		return fallback
+		return 0, fmt.Errorf("%s must be an integer, got %q: %w", key, value, err)
 	}
 
-	return parsed
+	return parsed, nil
 }
 
-func getFloat(key string, fallback float64) float64 {
+func getFloat(key string, fallback float64) (float64, error) {
 	value := strings.TrimSpace(os.Getenv(key))
 	if value == "" {
-		return fallback
+		return fallback, nil
 	}
 
 	parsed, err := strconv.ParseFloat(value, 64)
 	if err != nil {
-		return fallback
+		return 0, fmt.Errorf("%s must be a number, got %q: %w", key, value, err)
+	}
+	if math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+		return 0, fmt.Errorf("%s must be finite, got %q", key, value)
 	}
 
-	return parsed
+	return parsed, nil
 }
 
-func getBool(key string, fallback bool) bool {
+func getBool(key string, fallback bool) (bool, error) {
 	value := strings.TrimSpace(os.Getenv(key))
 	if value == "" {
-		return fallback
+		return fallback, nil
 	}
 
 	parsed, err := strconv.ParseBool(value)
 	if err != nil {
-		return fallback
+		return false, fmt.Errorf("%s must be a boolean, got %q: %w", key, value, err)
 	}
 
-	return parsed
+	return parsed, nil
 }
 
-func getDuration(key string, fallback time.Duration) time.Duration {
+func getDuration(key string, fallback time.Duration) (time.Duration, error) {
 	value := strings.TrimSpace(os.Getenv(key))
 	if value == "" {
-		return fallback
+		return fallback, nil
 	}
 
 	parsed, err := time.ParseDuration(value)
 	if err != nil {
-		return fallback
+		return 0, fmt.Errorf("%s must be a duration, got %q: %w", key, value, err)
 	}
 
-	return parsed
+	return parsed, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadDefaults(t *testing.T) {
+	setBaseEnvironment(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.PlaylistSize != defaultPlaylistSize {
+		t.Fatalf("expected playlist size %d, got %d", defaultPlaylistSize, cfg.PlaylistSize)
+	}
+	if cfg.RunTimeout != defaultRunTimeout {
+		t.Fatalf("expected timeout %s, got %s", defaultRunTimeout, cfg.RunTimeout)
+	}
+}
+
+func TestLoadRejectsInvalidEnvironmentValues(t *testing.T) {
+	tests := []struct {
+		key   string
+		value string
+		want  string
+	}{
+		{key: "PLAYLIST_SIZE", value: "many", want: "must be an integer"},
+		{key: "ENABLE_STATE_CACHE", value: "sometimes", want: "must be a boolean"},
+		{key: "RUN_TIMEOUT", value: "later", want: "must be a duration"},
+		{key: "RUN_TIMEOUT", value: "0s", want: "must be positive"},
+		{key: "SCORE_WEIGHT_PLAYCOUNT", value: "NaN", want: "must be finite"},
+		{key: "SCORE_WEIGHT_RECENCY", value: "-1", want: "must be non-negative"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.key+"="+test.value, func(t *testing.T) {
+			setBaseEnvironment(t)
+			t.Setenv(test.key, test.value)
+
+			_, err := Load()
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("expected error containing %q, got %v", test.want, err)
+			}
+		})
+	}
+}
+
+func TestLoadAcceptsExplicitValues(t *testing.T) {
+	setBaseEnvironment(t)
+	t.Setenv("PLAYLIST_SIZE", "25")
+	t.Setenv("ENABLE_STATE_CACHE", "false")
+	t.Setenv("RUN_TIMEOUT", "2m")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.PlaylistSize != 25 || cfg.EnableState || cfg.RunTimeout != 2*time.Minute {
+		t.Fatalf("unexpected parsed config: %+v", cfg)
+	}
+}
+
+func setBaseEnvironment(t *testing.T) {
+	t.Helper()
+	t.Setenv("NAVIDROME_URL", "http://navidrome:4533")
+	t.Setenv("NAVIDROME_USER", "listener")
+	t.Setenv("NAVIDROME_PASSWORD", "secret")
+	for _, key := range []string{
+		"PLAYLIST_SIZE",
+		"ALBUM_PAGE_SIZE",
+		"ENABLE_STATE_CACHE",
+		"RUN_TIMEOUT",
+		"MIN_CANDIDATE_BACKFILL",
+		"SCORE_WEIGHT_PLAYCOUNT",
+		"SCORE_WEIGHT_RECENCY",
+		"SCORE_WEIGHT_FRESHNESS",
+		"SCORE_DECAY_DAYS",
+		"STATE_FILE",
+		"STATE_DIR",
+	} {
+		t.Setenv(key, "")
+	}
+}

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -20,6 +20,7 @@ type TrackFeatures struct {
 	RecencyTrendScore   float64
 	RepeatFatigueScore  float64
 	ArtistSaturation    float64
+	ArtistAffinity      float64
 	AlbumSaturation     float64
 	NoveltyScore        float64
 	StabilityScore      float64
@@ -38,6 +39,7 @@ type Stats struct {
 	TracksWithLastPlayed int
 	TracksWithPlayCount  int
 	MaxArtistCount       int
+	MaxArtistPlayCount   int
 	MaxAlbumCount        int
 }
 
@@ -52,12 +54,14 @@ func NewBuilder(logger *log.Logger) *Builder {
 func (b *Builder) Build(tracks []model.Track, previous *state.HistoryState, now time.Time) Dataset {
 	playCounts := make([]int, 0, len(tracks))
 	artistCounts := make(map[string]int)
+	artistPlayCounts := make(map[string]int)
 	albumCounts := make(map[string]int)
 	stats := Stats{TotalTracks: len(tracks)}
 
 	for _, track := range tracks {
 		playCounts = append(playCounts, track.PlayCount)
 		artistCounts[groupKey(track.Artist)]++
+		artistPlayCounts[groupKey(track.Artist)] += track.PlayCount
 		albumCounts[groupKey(track.Album)]++
 		if !track.LastPlayed.IsZero() {
 			stats.TracksWithLastPlayed++
@@ -69,6 +73,7 @@ func (b *Builder) Build(tracks []model.Track, previous *state.HistoryState, now 
 
 	slices.Sort(playCounts)
 	stats.MaxArtistCount = maxMapValue(artistCounts)
+	stats.MaxArtistPlayCount = maxMapValue(artistPlayCounts)
 	stats.MaxAlbumCount = maxMapValue(albumCounts)
 
 	items := make([]TrackFeatures, 0, len(tracks))
@@ -89,6 +94,7 @@ func (b *Builder) Build(tracks []model.Track, previous *state.HistoryState, now 
 		recencyTrend := clamp01(playDelta/5.0)*recencyFactor + clamp01(recencyFactor*0.25)
 		repeatFatigue := clamp01(recencyFactor*0.8 + clamp01(playDelta/6.0)*0.6)
 		artistSaturation := normalizeCount(artistCounts[groupKey(track.Artist)], stats.MaxArtistCount)
+		artistAffinity := normalizeLogCount(artistPlayCounts[groupKey(track.Artist)], stats.MaxArtistPlayCount)
 		albumSaturation := normalizeCount(albumCounts[groupKey(track.Album)], stats.MaxAlbumCount)
 		noveltyScore := clamp01((1-playPercentile)*0.7 + freshnessFactor*0.3)
 		stabilityScore := clamp01(float64(previousSnapshot.SeenCount) / 5.0)
@@ -104,6 +110,7 @@ func (b *Builder) Build(tracks []model.Track, previous *state.HistoryState, now 
 			recencyTrend,
 			1 - repeatFatigue,
 			1 - artistSaturation,
+			artistAffinity,
 			1 - albumSaturation,
 			noveltyScore,
 			stabilityScore,
@@ -120,6 +127,7 @@ func (b *Builder) Build(tracks []model.Track, previous *state.HistoryState, now 
 			RecencyTrendScore:   clamp01(recencyTrend),
 			RepeatFatigueScore:  repeatFatigue,
 			ArtistSaturation:    artistSaturation,
+			ArtistAffinity:      artistAffinity,
 			AlbumSaturation:     albumSaturation,
 			NoveltyScore:        noveltyScore,
 			StabilityScore:      stabilityScore,
@@ -193,6 +201,14 @@ func normalizeCount(value, maxValue int) float64 {
 		return 0
 	}
 	return clamp01(float64(value-1) / float64(maxValue-1))
+}
+
+func normalizeLogCount(value, maxValue int) float64 {
+	if value <= 0 || maxValue <= 0 {
+		return 0
+	}
+
+	return clamp01(math.Log1p(float64(value)) / math.Log1p(float64(maxValue)))
 }
 
 func maxMapValue(items map[string]int) int {

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -63,6 +63,9 @@ func TestBuildDerivesExpectedSignals(t *testing.T) {
 	if rising.StabilityScore <= 0 {
 		t.Fatalf("expected positive stability score, got %.4f", rising.StabilityScore)
 	}
+	if rising.ArtistAffinity != 1 {
+		t.Fatalf("expected strongest artist affinity, got %.4f", rising.ArtistAffinity)
+	}
 
 	newTrack, ok := dataset.Get("new")
 	if !ok {
@@ -73,6 +76,9 @@ func TestBuildDerivesExpectedSignals(t *testing.T) {
 	}
 	if newTrack.NoveltyScore <= rising.NoveltyScore {
 		t.Fatalf("expected new track novelty %.4f to exceed rising track novelty %.4f", newTrack.NoveltyScore, rising.NoveltyScore)
+	}
+	if newTrack.ArtistAffinity != 0 {
+		t.Fatalf("expected unplayed artist affinity 0, got %.4f", newTrack.ArtistAffinity)
 	}
 }
 

--- a/internal/model/track.go
+++ b/internal/model/track.go
@@ -7,6 +7,8 @@ type Track struct {
 	Title      string
 	Artist     string
 	Album      string
+	Genre      string
+	Duration   int
 	PlayCount  int
 	LastPlayed time.Time
 	Created    time.Time

--- a/internal/navidrome/client.go
+++ b/internal/navidrome/client.go
@@ -39,6 +39,8 @@ type TrackPayload struct {
 	Title      string `json:"title"`
 	Artist     string `json:"artist"`
 	Album      string `json:"album"`
+	Genre      string `json:"genre"`
+	Duration   int    `json:"duration"`
 	PlayCount  int    `json:"playCount"`
 	Played     string `json:"played"`
 	Created    string `json:"created"`

--- a/internal/playlist/generator.go
+++ b/internal/playlist/generator.go
@@ -1,6 +1,8 @@
 package playlist
 
 import (
+	"fmt"
+	"hash/fnv"
 	"log"
 	"math"
 	"sort"
@@ -19,6 +21,8 @@ const (
 	defaultArtistLimit = 3
 	defaultAlbumLimit  = 3
 	maxBackfillLimit   = 5
+	quickTrackSeconds  = 4 * 60
+	longformSeconds    = 8 * 60
 )
 
 type Definition struct {
@@ -38,6 +42,14 @@ type scoredTrack struct {
 	score float64
 }
 
+type recipe struct {
+	name       string
+	eligible   func(features.TrackFeatures) bool
+	score      func(features.TrackFeatures) float64
+	carryover  float64
+	weekJitter float64
+}
+
 func NewGenerator(cfg config.Config, logger *log.Logger) *Generator {
 	return &Generator{
 		size:        cfg.PlaylistSize,
@@ -48,99 +60,246 @@ func NewGenerator(cfg config.Config, logger *log.Logger) *Generator {
 }
 
 func (g *Generator) Generate(dataset features.Dataset, previous *state.HistoryState, now time.Time) []Definition {
-	discoverWeekly := g.rankPlaylist("Discover Weekly", dataset.Items, previous, func(track features.TrackFeatures) float64 {
-		return g.engine.BaseScore(track) +
-			1.6*track.NoveltyScore +
-			0.6*freshnessCurve(track.DaysSinceAdded, 0, 120) +
-			0.4*windowScore(track.DaysSinceLastPlayed, 14, 120, 35) -
-			0.7*track.PlayCountPercentile
-	})
+	ranked := make(map[string][]features.TrackFeatures)
+	for _, currentRecipe := range g.recipes() {
+		ranked[currentRecipe.name] = g.rankRecipe(currentRecipe, dataset.Items, previous, now)
+	}
 
-	rediscover := g.rankPlaylist("Rediscover", dataset.Items, previous, func(track features.TrackFeatures) float64 {
-		return g.engine.BaseScore(track) +
-			1.4*windowScore(track.DaysSinceLastPlayed, 45, 180, 40) +
-			0.9*track.PlayCountPercentile +
-			0.4*track.StabilityScore -
-			0.3*track.NoveltyScore
-	})
-
-	topThisMonth := g.rankPlaylist("Top This Month", dataset.Items, previous, func(track features.TrackFeatures) float64 {
-		return g.engine.BaseScore(track) +
-			1.8*windowScore(track.DaysSinceLastPlayed, 0, 30, 12) +
-			0.9*track.RecencyTrendScore +
-			0.4*track.PlayCountDelta +
-			0.5*track.PlayCountPercentile
-	})
-
-	hiddenGems := g.rankPlaylist("Hidden Gems", dataset.Items, previous, func(track features.TrackFeatures) float64 {
-		return g.engine.BaseScore(track) +
-			1.5*track.NoveltyScore +
-			0.8*(1-track.PlayCountPercentile) +
-			0.35*boolScore(track.Track.Starred) +
-			0.35*clamp01(float64(track.Track.Rating)/5.0) +
-			0.3*windowScore(track.DaysSinceLastPlayed, 21, 240, 60)
-	})
-
-	longTimeNoSee := g.rankPlaylist("Long Time No See", dataset.Items, previous, func(track features.TrackFeatures) float64 {
-		return g.engine.BaseScore(track) +
-			1.6*longTailScore(track.DaysSinceLastPlayed, 120, 45) +
-			0.7*track.PlayCountPercentile +
-			0.4*track.StabilityScore -
-			0.2*track.NoveltyScore
-	})
-
-	comfortShuffle := g.rankPlaylist("Comfort Shuffle", dataset.Items, previous, func(track features.TrackFeatures) float64 {
-		return g.engine.BaseScore(track) +
-			1.5*windowScore(track.DaysSinceLastPlayed, 7, 180, 45) +
-			1.0*track.PlayCountPercentile +
-			0.5*track.StabilityScore -
-			0.4*track.RepeatFatigueScore
-	})
-
-	moreLikeHiddenGems := g.similarPlaylist(
+	ranked["More Like Hidden Gems"] = g.similarPlaylist(
 		"More Like Hidden Gems",
 		dataset,
 		previous,
-		hiddenGems,
-		func(track features.TrackFeatures, similarityScore float64) float64 {
-			return 1.5*similarityScore + g.engine.BaseScore(track) + 0.8*track.NoveltyScore
+		now,
+		ranked["Hidden Gems"],
+		false,
+		-0.35,
+		0.25,
+		func(track features.TrackFeatures, similarityScore, genreMatch float64) float64 {
+			return 1.6*similarityScore + 0.3*genreMatch + g.engine.BaseScore(track) + 0.8*track.NoveltyScore
 		},
 	)
 
-	artistAdjacentComfort := g.similarPlaylist(
+	ranked["Artist Adjacent Comfort"] = g.similarPlaylist(
 		"Artist Adjacent Comfort",
 		dataset,
 		previous,
-		comfortShuffle,
-		func(track features.TrackFeatures, similarityScore float64) float64 {
-			return 1.5*similarityScore + g.engine.BaseScore(track) + 0.5*track.StabilityScore + 0.4*track.PlayCountPercentile
+		now,
+		ranked["Comfort Shuffle"],
+		true,
+		-0.2,
+		0.35,
+		func(track features.TrackFeatures, similarityScore, genreMatch float64) float64 {
+			return 1.5*similarityScore + 0.4*genreMatch + g.engine.BaseScore(track) + 0.5*track.StabilityScore
 		},
 	)
 
-	definitions := []Definition{
-		{Name: "Discover Weekly", Tracks: toTracks(discoverWeekly)},
-		{Name: "Rediscover", Tracks: toTracks(rediscover)},
-		{Name: "Top This Month", Tracks: toTracks(topThisMonth)},
-		{Name: "Hidden Gems", Tracks: toTracks(hiddenGems)},
-		{Name: "Long Time No See", Tracks: toTracks(longTimeNoSee)},
-		{Name: "Comfort Shuffle", Tracks: toTracks(comfortShuffle)},
-		{Name: "More Like Hidden Gems", Tracks: toTracks(moreLikeHiddenGems)},
-		{Name: "Artist Adjacent Comfort", Tracks: toTracks(artistAdjacentComfort)},
+	names := []string{
+		"Discover Weekly",
+		"Rediscover",
+		"Top This Month",
+		"Hidden Gems",
+		"Long Time No See",
+		"Comfort Shuffle",
+		"More Like Hidden Gems",
+		"Artist Adjacent Comfort",
+		"Fresh & Unplayed",
+		"Forgotten Favorites",
+		"Rising This Week",
+		"Deep Cuts",
+		"Quick Mix",
+		"Longform",
 	}
 
-	for _, definition := range definitions {
+	definitions := make([]Definition, 0, len(names))
+	for _, name := range names {
+		definition := Definition{Name: name, Tracks: toTracks(ranked[name])}
+		definitions = append(definitions, definition)
 		g.logger.Printf("generated playlist %q with %d tracks", definition.Name, len(definition.Tracks))
 	}
 
 	return definitions
 }
 
+func (g *Generator) recipes() []recipe {
+	return []recipe{
+		{
+			name: "Discover Weekly",
+			eligible: func(track features.TrackFeatures) bool {
+				return !track.HasLastPlayed || track.Track.PlayCount <= 3 || track.DaysSinceAdded <= 180
+			},
+			score: func(track features.TrackFeatures) float64 {
+				return g.engine.BaseScore(track) +
+					1.6*track.NoveltyScore +
+					0.6*freshnessCurve(track.DaysSinceAdded, 0, 180) -
+					0.7*track.PlayCountPercentile -
+					0.4*track.RepeatFatigueScore
+			},
+			carryover:  -0.65,
+			weekJitter: 0.35,
+		},
+		{
+			name: "Rediscover",
+			eligible: func(track features.TrackFeatures) bool {
+				return track.HasLastPlayed && track.DaysSinceLastPlayed >= 45 && track.DaysSinceLastPlayed <= 720
+			},
+			score: func(track features.TrackFeatures) float64 {
+				return g.engine.BaseScore(track) +
+					1.4*windowScore(track.DaysSinceLastPlayed, 60, 365, 45) +
+					0.9*track.PlayCountPercentile +
+					0.4*track.StabilityScore -
+					0.3*track.RepeatFatigueScore
+			},
+			carryover:  -0.1,
+			weekJitter: 0.15,
+		},
+		{
+			name: "Top This Month",
+			eligible: func(track features.TrackFeatures) bool {
+				return track.HasLastPlayed && track.DaysSinceLastPlayed <= 31 && (track.PlayCountDelta > 0 || track.Track.PlayCount > 0)
+			},
+			score: func(track features.TrackFeatures) float64 {
+				return g.engine.BaseScore(track) +
+					1.8*windowScore(track.DaysSinceLastPlayed, 0, 31, 12) +
+					1.2*deltaScore(track.PlayCountDelta) +
+					0.5*track.PlayCountPercentile
+			},
+			carryover:  0.15,
+			weekJitter: 0.05,
+		},
+		{
+			name: "Hidden Gems",
+			eligible: func(track features.TrackFeatures) bool {
+				return track.PlayCountPercentile <= 0.55 || track.Track.Starred || track.Track.Rating >= 4
+			},
+			score: func(track features.TrackFeatures) float64 {
+				return g.engine.BaseScore(track) +
+					1.5*track.NoveltyScore +
+					0.8*(1-track.PlayCountPercentile) +
+					0.45*preferenceScore(track) +
+					0.3*windowScore(track.DaysSinceLastPlayed, 21, 240, 60)
+			},
+			carryover:  -0.3,
+			weekJitter: 0.25,
+		},
+		{
+			name: "Long Time No See",
+			eligible: func(track features.TrackFeatures) bool {
+				return track.HasLastPlayed && track.DaysSinceLastPlayed >= 120
+			},
+			score: func(track features.TrackFeatures) float64 {
+				return g.engine.BaseScore(track) +
+					1.6*longTailScore(track.DaysSinceLastPlayed, 120, 60) +
+					0.8*track.PlayCountPercentile +
+					0.4*track.StabilityScore
+			},
+			carryover:  -0.4,
+			weekJitter: 0.2,
+		},
+		{
+			name: "Comfort Shuffle",
+			eligible: func(track features.TrackFeatures) bool {
+				return track.HasLastPlayed && (track.PlayCountPercentile >= 0.55 || track.Track.Starred || track.Track.Rating >= 4)
+			},
+			score: func(track features.TrackFeatures) float64 {
+				return g.engine.BaseScore(track) +
+					1.1*preferenceScore(track) +
+					0.5*track.StabilityScore -
+					0.7*track.RepeatFatigueScore
+			},
+			carryover:  0.1,
+			weekJitter: 0.9,
+		},
+		{
+			name: "Fresh & Unplayed",
+			eligible: func(track features.TrackFeatures) bool {
+				return !track.HasLastPlayed && track.DaysSinceAdded <= 180
+			},
+			score: func(track features.TrackFeatures) float64 {
+				return 2.0*freshnessCurve(track.DaysSinceAdded, 0, 180) +
+					1.8*track.NoveltyScore +
+					0.4*track.ArtistAffinity +
+					0.3*preferenceScore(track)
+			},
+			carryover:  -0.8,
+			weekJitter: 0.4,
+		},
+		{
+			name: "Forgotten Favorites",
+			eligible: func(track features.TrackFeatures) bool {
+				favorite := track.Track.Starred || track.Track.Rating >= 4 || track.PlayCountPercentile >= 0.65
+				return favorite && track.HasLastPlayed && track.DaysSinceLastPlayed >= 180
+			},
+			score: func(track features.TrackFeatures) float64 {
+				return 1.5*preferenceScore(track) +
+					1.4*longTailScore(track.DaysSinceLastPlayed, 180, 75) +
+					0.6*track.StabilityScore
+			},
+			carryover:  -0.5,
+			weekJitter: 0.25,
+		},
+		{
+			name: "Rising This Week",
+			eligible: func(track features.TrackFeatures) bool {
+				return track.HasLastPlayed && track.DaysSinceLastPlayed <= 14 && track.PlayCountDelta > 0
+			},
+			score: func(track features.TrackFeatures) float64 {
+				return 1.8*deltaScore(track.PlayCountDelta) +
+					1.3*track.RecencyTrendScore +
+					0.6*track.PlayCountPercentile +
+					0.3*preferenceScore(track)
+			},
+			carryover:  0.1,
+			weekJitter: 0.05,
+		},
+		{
+			name: "Deep Cuts",
+			eligible: func(track features.TrackFeatures) bool {
+				return track.ArtistAffinity >= 0.35 && track.PlayCountPercentile <= 0.55
+			},
+			score: func(track features.TrackFeatures) float64 {
+				return 1.7*track.ArtistAffinity +
+					1.4*track.NoveltyScore +
+					0.5*preferenceScore(track) +
+					0.4*freshnessCurve(track.DaysSinceAdded, 0, 365)
+			},
+			carryover:  -0.35,
+			weekJitter: 0.35,
+		},
+		{
+			name: "Quick Mix",
+			eligible: func(track features.TrackFeatures) bool {
+				return track.Track.Duration > 0 && track.Track.Duration <= quickTrackSeconds
+			},
+			score: func(track features.TrackFeatures) float64 {
+				return g.engine.BaseScore(track) + 0.5*preferenceScore(track) - 0.4*track.RepeatFatigueScore
+			},
+			carryover:  -0.15,
+			weekJitter: 0.65,
+		},
+		{
+			name: "Longform",
+			eligible: func(track features.TrackFeatures) bool {
+				return track.Track.Duration >= longformSeconds
+			},
+			score: func(track features.TrackFeatures) float64 {
+				return g.engine.BaseScore(track) + 0.6*preferenceScore(track) - 0.3*track.RepeatFatigueScore
+			},
+			carryover:  -0.1,
+			weekJitter: 0.5,
+		},
+	}
+}
+
 func (g *Generator) similarPlaylist(
 	name string,
 	dataset features.Dataset,
 	previous *state.HistoryState,
+	now time.Time,
 	seeds []features.TrackFeatures,
-	scorer func(track features.TrackFeatures, similarityScore float64) float64,
+	excludeSeedArtists bool,
+	carryover float64,
+	weekJitter float64,
+	scorer func(track features.TrackFeatures, similarityScore, genreMatch float64) float64,
 ) []features.TrackFeatures {
 	if len(seeds) == 0 {
 		return nil
@@ -149,13 +308,16 @@ func (g *Generator) similarPlaylist(
 	seedVectors := make([][]float64, 0, min(len(seeds), 10))
 	seedIDs := make(map[string]struct{}, len(seeds))
 	seedArtists := make(map[string]struct{}, len(seeds))
+	seedGenreCounts := make(map[string]int, len(seeds))
 	for index, seed := range seeds {
-		if index >= 10 {
-			break
-		}
-		seedVectors = append(seedVectors, seed.SimilarityVector)
 		seedIDs[seed.Track.ID] = struct{}{}
 		seedArtists[canonicalKey(seed.Track.Artist)] = struct{}{}
+		if genre := canonicalKey(seed.Track.Genre); genre != "__unknown__" {
+			seedGenreCounts[genre]++
+		}
+		if index < 10 {
+			seedVectors = append(seedVectors, seed.SimilarityVector)
+		}
 	}
 
 	centroid := similarity.Centroid(seedVectors)
@@ -168,40 +330,51 @@ func (g *Generator) similarPlaylist(
 		if _, isSeed := seedIDs[track.Track.ID]; isSeed {
 			continue
 		}
+		_, duplicateArtist := seedArtists[canonicalKey(track.Track.Artist)]
+		if excludeSeedArtists && duplicateArtist {
+			continue
+		}
 
-		score := scorer(track, similarity.CosineSimilarity(track.SimilarityVector, centroid))
-		if _, duplicateArtist := seedArtists[canonicalKey(track.Track.Artist)]; duplicateArtist {
+		genreMatch := 0.0
+		if matches := seedGenreCounts[canonicalKey(track.Track.Genre)]; matches > 0 {
+			genreMatch = float64(matches) / float64(len(seeds))
+		}
+		score := scorer(track, similarity.CosineSimilarity(track.SimilarityVector, centroid), genreMatch)
+		if duplicateArtist {
 			score -= 0.25
 		}
-		score += g.previousPlaylistBoost(previous, name, track.Track.ID)
-
+		score += g.playlistCarryover(previous, name, track.Track.ID, carryover)
+		score += centeredWeeklyJitter(name, track.Track.ID, now) * weekJitter
 		scored = append(scored, scoredTrack{track: track, score: score})
 	}
 
-	sort.SliceStable(scored, func(i, j int) bool {
-		return scored[i].score > scored[j].score
-	})
-
+	sortScored(scored)
 	return g.finalize(name, scored)
 }
 
-func (g *Generator) rankPlaylist(
-	name string,
-	items []features.TrackFeatures,
-	previous *state.HistoryState,
-	scorer func(track features.TrackFeatures) float64,
-) []features.TrackFeatures {
+func (g *Generator) rankRecipe(currentRecipe recipe, items []features.TrackFeatures, previous *state.HistoryState, now time.Time) []features.TrackFeatures {
 	scored := make([]scoredTrack, 0, len(items))
 	for _, track := range items {
-		score := scorer(track) + g.previousPlaylistBoost(previous, name, track.Track.ID)
+		if currentRecipe.eligible != nil && !currentRecipe.eligible(track) {
+			continue
+		}
+		score := currentRecipe.score(track)
+		score += g.playlistCarryover(previous, currentRecipe.name, track.Track.ID, currentRecipe.carryover)
+		score += centeredWeeklyJitter(currentRecipe.name, track.Track.ID, now) * currentRecipe.weekJitter
 		scored = append(scored, scoredTrack{track: track, score: score})
 	}
 
+	sortScored(scored)
+	return g.finalize(currentRecipe.name, scored)
+}
+
+func sortScored(scored []scoredTrack) {
 	sort.SliceStable(scored, func(i, j int) bool {
+		if scored[i].score == scored[j].score {
+			return scored[i].track.Track.ID < scored[j].track.Track.ID
+		}
 		return scored[i].score > scored[j].score
 	})
-
-	return g.finalize(name, scored)
 }
 
 func (g *Generator) finalize(name string, scored []scoredTrack) []features.TrackFeatures {
@@ -214,12 +387,20 @@ func (g *Generator) finalize(name string, scored []scoredTrack) []features.Track
 	return result
 }
 
-func (g *Generator) previousPlaylistBoost(previous *state.HistoryState, playlistName, trackID string) float64 {
+func (g *Generator) playlistCarryover(previous *state.HistoryState, playlistName, trackID string, adjustment float64) float64 {
 	if previous == nil || !previous.PlaylistContains(playlistName, trackID) {
 		return 0
 	}
 
-	return 0.18
+	return adjustment
+}
+
+func centeredWeeklyJitter(playlistName, trackID string, now time.Time) float64 {
+	year, week := now.ISOWeek()
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(fmt.Sprintf("%s\x00%s\x00%d\x00%d", playlistName, trackID, year, week)))
+	value := float64(hasher.Sum64()%1_000_000) / 1_000_000
+	return value - 0.5
 }
 
 func toTracks(items []features.TrackFeatures) []model.Track {
@@ -241,8 +422,8 @@ func limitDiversity(items []scoredTrack, size, maxPerArtist, maxPerAlbum int) []
 			break
 		}
 
-		artistKey := canonicalKey(item.track.Track.Artist)
-		albumKey := canonicalKey(item.track.Track.Album)
+		artistKey := diversityKey(item.track.Track.Artist, item.track.Track.ID)
+		albumKey := diversityKey(item.track.Track.Album, item.track.Track.ID)
 		if artistCounts[artistKey] >= maxPerArtist || albumCounts[albumKey] >= maxPerAlbum {
 			continue
 		}
@@ -263,6 +444,14 @@ func canonicalKey(value string) string {
 	return trimmed
 }
 
+func diversityKey(value, trackID string) string {
+	key := canonicalKey(value)
+	if key == "__unknown__" || key == "unknown artist" || key == "unknown album" {
+		return key + ":" + trackID
+	}
+	return key
+}
+
 func windowScore(value, start, end, softness float64) float64 {
 	if value >= start && value <= end {
 		return 1
@@ -274,14 +463,30 @@ func windowScore(value, start, end, softness float64) float64 {
 }
 
 func longTailScore(value, start, softness float64) float64 {
-	if value >= start {
-		return 1 - math.Exp(-(value-start)/softness)
+	if value <= start {
+		return 0
 	}
-	return math.Exp(-(start - value) / softness)
+	return 1 - math.Exp(-(value-start)/softness)
 }
 
 func freshnessCurve(value, start, end float64) float64 {
-	return windowScore(value, start, end, 45)
+	if value <= start {
+		return 1
+	}
+	if value >= end || end <= start {
+		return 0
+	}
+	return 1 - (value-start)/(end-start)
+}
+
+func preferenceScore(track features.TrackFeatures) float64 {
+	rating := clamp01(float64(track.Track.Rating) / 5.0)
+	starred := boolScore(track.Track.Starred)
+	return clamp01(0.5*track.PlayCountPercentile + 0.3*rating + 0.2*starred)
+}
+
+func deltaScore(value float64) float64 {
+	return clamp01(value / 5.0)
 }
 
 func boolScore(value bool) float64 {

--- a/internal/playlist/generator_test.go
+++ b/internal/playlist/generator_test.go
@@ -14,20 +14,21 @@ import (
 func TestGeneratorProducesNonEmptySoftRankedPlaylists(t *testing.T) {
 	now := time.Date(2026, 4, 6, 12, 0, 0, 0, time.UTC)
 	tracks := []model.Track{
-		{ID: "1", Title: "One", Artist: "Artist A", Album: "Album A", PlayCount: 6, LastPlayed: now.Add(-50 * 24 * time.Hour), Created: now.Add(-200 * 24 * time.Hour), Rating: 4},
-		{ID: "2", Title: "Two", Artist: "Artist B", Album: "Album B", PlayCount: 4, LastPlayed: now.Add(-90 * 24 * time.Hour), Created: now.Add(-120 * 24 * time.Hour), Rating: 5, Starred: true},
-		{ID: "3", Title: "Three", Artist: "Artist C", Album: "Album C", PlayCount: 0, Created: now.Add(-5 * 24 * time.Hour)},
-		{ID: "4", Title: "Four", Artist: "Artist D", Album: "Album D", PlayCount: 9, LastPlayed: now.Add(-14 * 24 * time.Hour), Created: now.Add(-400 * 24 * time.Hour)},
-		{ID: "5", Title: "Five", Artist: "Artist E", Album: "Album E", PlayCount: 8, LastPlayed: now.Add(-150 * 24 * time.Hour), Created: now.Add(-500 * 24 * time.Hour)},
-		{ID: "6", Title: "Six", Artist: "Artist F", Album: "Album F", PlayCount: 1, LastPlayed: now.Add(-200 * 24 * time.Hour), Created: now.Add(-220 * 24 * time.Hour)},
-		{ID: "7", Title: "Seven", Artist: "Artist G", Album: "Album G", PlayCount: 5, LastPlayed: now.Add(-20 * 24 * time.Hour), Created: now.Add(-70 * 24 * time.Hour)},
-		{ID: "8", Title: "Eight", Artist: "Artist H", Album: "Album H", PlayCount: 2, LastPlayed: now.Add(-300 * 24 * time.Hour), Created: now.Add(-350 * 24 * time.Hour)},
+		{ID: "1", Title: "One", Artist: "Artist A", Album: "Album A", Genre: "Rock", Duration: 210, PlayCount: 6, LastPlayed: now.Add(-50 * 24 * time.Hour), Created: now.Add(-200 * 24 * time.Hour), Rating: 4},
+		{ID: "2", Title: "Two", Artist: "Artist B", Album: "Album B", Genre: "Jazz", Duration: 600, PlayCount: 4, LastPlayed: now.Add(-90 * 24 * time.Hour), Created: now.Add(-120 * 24 * time.Hour), Rating: 5, Starred: true},
+		{ID: "3", Title: "Three", Artist: "Artist C", Album: "Album C", Genre: "Rock", Duration: 190, PlayCount: 0, Created: now.Add(-5 * 24 * time.Hour)},
+		{ID: "4", Title: "Four", Artist: "Artist D", Album: "Album D", Genre: "Pop", Duration: 250, PlayCount: 9, LastPlayed: now.Add(-14 * 24 * time.Hour), Created: now.Add(-400 * 24 * time.Hour)},
+		{ID: "5", Title: "Five", Artist: "Artist E", Album: "Album E", Genre: "Jazz", Duration: 620, PlayCount: 8, LastPlayed: now.Add(-150 * 24 * time.Hour), Created: now.Add(-500 * 24 * time.Hour)},
+		{ID: "6", Title: "Six", Artist: "Artist F", Album: "Album F", Genre: "Rock", Duration: 200, PlayCount: 1, LastPlayed: now.Add(-200 * 24 * time.Hour), Created: now.Add(-220 * 24 * time.Hour)},
+		{ID: "7", Title: "Seven", Artist: "Artist G", Album: "Album G", Genre: "Pop", Duration: 300, PlayCount: 5, LastPlayed: now.Add(-20 * 24 * time.Hour), Created: now.Add(-70 * 24 * time.Hour)},
+		{ID: "8", Title: "Eight", Artist: "Artist H", Album: "Album H", Genre: "Jazz", Duration: 700, PlayCount: 2, LastPlayed: now.Add(-300 * 24 * time.Hour), Created: now.Add(-350 * 24 * time.Hour), Starred: true},
 	}
 
 	previous := state.NewHistoryState()
 	previous.Playlists["Comfort Shuffle"] = state.PlaylistSnapshot{TrackIDs: []string{"1"}}
 	previous.Tracks["1"] = state.TrackSnapshot{ID: "1", PlayCount: 5, SeenCount: 3}
 	previous.Tracks["2"] = state.TrackSnapshot{ID: "2", PlayCount: 4, SeenCount: 3}
+	previous.Tracks["4"] = state.TrackSnapshot{ID: "4", PlayCount: 8, SeenCount: 3}
 
 	builder := features.NewBuilder(log.New(testWriter{t}, "", 0))
 	dataset := builder.Build(tracks, previous, now)
@@ -43,8 +44,8 @@ func TestGeneratorProducesNonEmptySoftRankedPlaylists(t *testing.T) {
 	}, log.New(testWriter{t}, "", 0))
 
 	playlists := generator.Generate(dataset, previous, now)
-	if len(playlists) < 8 {
-		t.Fatalf("expected 8 playlists, got %d", len(playlists))
+	if len(playlists) != 14 {
+		t.Fatalf("expected 14 playlists, got %d", len(playlists))
 	}
 
 	required := map[string]int{
@@ -53,12 +54,102 @@ func TestGeneratorProducesNonEmptySoftRankedPlaylists(t *testing.T) {
 		"Comfort Shuffle":         1,
 		"More Like Hidden Gems":   1,
 		"Artist Adjacent Comfort": 1,
+		"Fresh & Unplayed":        1,
+		"Forgotten Favorites":     1,
+		"Rising This Week":        1,
+		"Deep Cuts":               1,
+		"Quick Mix":               1,
+		"Longform":                1,
 	}
 
 	for _, definition := range playlists {
 		if minTracks, ok := required[definition.Name]; ok && len(definition.Tracks) < minTracks {
 			t.Fatalf("expected playlist %q to have at least %d track, got %d", definition.Name, minTracks, len(definition.Tracks))
 		}
+	}
+
+	assertTracksMatch(t, playlists, "Long Time No See", func(track model.Track) bool {
+		return !track.LastPlayed.IsZero() && now.Sub(track.LastPlayed) >= 120*24*time.Hour
+	})
+	assertTracksMatch(t, playlists, "Fresh & Unplayed", func(track model.Track) bool {
+		return track.LastPlayed.IsZero() && now.Sub(track.Created) <= 180*24*time.Hour
+	})
+	assertTracksMatch(t, playlists, "Rising This Week", func(track model.Track) bool {
+		return track.ID == "4"
+	})
+	assertTracksMatch(t, playlists, "Quick Mix", func(track model.Track) bool {
+		return track.Duration > 0 && track.Duration <= quickTrackSeconds
+	})
+	assertTracksMatch(t, playlists, "Longform", func(track model.Track) bool {
+		return track.Duration >= longformSeconds
+	})
+}
+
+func TestSimilarPlaylistExcludesEverySeedTrack(t *testing.T) {
+	now := time.Date(2026, 4, 6, 12, 0, 0, 0, time.UTC)
+	seeds := make([]features.TrackFeatures, 0, 15)
+	items := make([]features.TrackFeatures, 0, 20)
+	for index := 0; index < 15; index++ {
+		seed := features.TrackFeatures{
+			Track:            model.Track{ID: "seed-" + string(rune('a'+index)), Artist: "Seed Artist", Album: "Seed Album"},
+			SimilarityVector: []float64{1, 0.5},
+		}
+		seeds = append(seeds, seed)
+		items = append(items, seed)
+	}
+	for index := 0; index < 5; index++ {
+		items = append(items, features.TrackFeatures{
+			Track: model.Track{
+				ID:     "candidate-" + string(rune('a'+index)),
+				Artist: "Candidate Artist " + string(rune('a'+index)),
+				Album:  "Candidate Album " + string(rune('a'+index)),
+			},
+			SimilarityVector: []float64{1, 0.5},
+		})
+	}
+
+	generator := newTestGenerator(t, 20, 0)
+	result := generator.similarPlaylist(
+		"Similar",
+		features.Dataset{Items: items},
+		state.NewHistoryState(),
+		now,
+		seeds,
+		false,
+		0,
+		0,
+		func(_ features.TrackFeatures, similarityScore, _ float64) float64 { return similarityScore },
+	)
+
+	if len(result) != 5 {
+		t.Fatalf("expected five non-seed candidates, got %d", len(result))
+	}
+	for _, track := range result {
+		if len(track.Track.ID) >= 5 && track.Track.ID[:5] == "seed-" {
+			t.Fatalf("seed track leaked into similar playlist: %s", track.Track.ID)
+		}
+	}
+}
+
+func TestWeeklyJitterIsStableWithinWeekAndRotatesAcrossWeeks(t *testing.T) {
+	first := time.Date(2026, 4, 6, 12, 0, 0, 0, time.UTC)
+	if centeredWeeklyJitter("Mix", "track", first) != centeredWeeklyJitter("Mix", "track", first.Add(2*24*time.Hour)) {
+		t.Fatalf("jitter changed within same ISO week")
+	}
+	if centeredWeeklyJitter("Mix", "track", first) == centeredWeeklyJitter("Mix", "track", first.Add(7*24*time.Hour)) {
+		t.Fatalf("jitter did not change across ISO weeks")
+	}
+}
+
+func TestAgeCurvesHaveExpectedDirection(t *testing.T) {
+	if freshnessCurve(5, 0, 180) <= freshnessCurve(170, 0, 180) {
+		t.Fatalf("newer track must receive stronger freshness score")
+	}
+	if longTailScore(120, 120, 60) != 0 {
+		t.Fatalf("long-tail score must start at zero at threshold")
+	}
+	if longTailScore(300, 120, 60) <= longTailScore(180, 120, 60) {
+		t.Fatalf("older eligible track must receive stronger long-tail score")
 	}
 }
 
@@ -79,16 +170,7 @@ func TestGeneratorEnforcesDiversityCaps(t *testing.T) {
 
 	builder := features.NewBuilder(log.New(testWriter{t}, "", 0))
 	dataset := builder.Build(tracks, state.NewHistoryState(), now)
-	generator := NewGenerator(config.Config{
-		PlaylistSize: 8,
-		MinBackfill:  0,
-		Weights: config.Weights{
-			PlayCount: 1,
-			Recency:   2,
-			Freshness: 1.5,
-			DecayDays: 45,
-		},
-	}, log.New(testWriter{t}, "", 0))
+	generator := newTestGenerator(t, 8, 0)
 
 	playlists := generator.Generate(dataset, state.NewHistoryState(), now)
 	for _, definition := range playlists {
@@ -96,6 +178,36 @@ func TestGeneratorEnforcesDiversityCaps(t *testing.T) {
 			t.Fatalf("expected diversity-limited playlist %q to top out at 5 tracks, got %d", definition.Name, len(definition.Tracks))
 		}
 	}
+}
+
+func newTestGenerator(t *testing.T, size, minBackfill int) *Generator {
+	t.Helper()
+	return NewGenerator(config.Config{
+		PlaylistSize: size,
+		MinBackfill:  minBackfill,
+		Weights: config.Weights{
+			PlayCount: 1,
+			Recency:   2,
+			Freshness: 1.5,
+			DecayDays: 45,
+		},
+	}, log.New(testWriter{t}, "", 0))
+}
+
+func assertTracksMatch(t *testing.T, playlists []Definition, name string, predicate func(model.Track) bool) {
+	t.Helper()
+	for _, definition := range playlists {
+		if definition.Name != name {
+			continue
+		}
+		for _, track := range definition.Tracks {
+			if !predicate(track) {
+				t.Fatalf("playlist %q contains ineligible track %+v", name, track)
+			}
+		}
+		return
+	}
+	t.Fatalf("missing playlist %q", name)
 }
 
 type testWriter struct {

--- a/internal/playlist/writer.go
+++ b/internal/playlist/writer.go
@@ -21,36 +21,28 @@ type playlistClient interface {
 type Writer struct {
 	client playlistClient
 	logger *log.Logger
-	dryRun bool
+	owner  string
 }
 
-func NewWriter(client playlistClient, logger *log.Logger, dryRun bool) *Writer {
+func NewWriter(client playlistClient, logger *log.Logger, owner string) *Writer {
 	return &Writer{
 		client: client,
 		logger: logger,
-		dryRun: dryRun,
+		owner:  strings.TrimSpace(owner),
 	}
 }
 
 func (w *Writer) Upsert(ctx context.Context, name string, tracks []model.Track) error {
 	songIDs := extractSongIDs(tracks)
-	if len(songIDs) == 0 {
-		w.logger.Printf("playlist %q has no tracks, skipping write", name)
-		return nil
-	}
-
-	if w.dryRun {
-		w.logger.Printf("dry-run playlist %q (%d tracks): %s", name, len(songIDs), strings.Join(songIDs, ","))
-		return nil
-	}
-
 	playlists, err := w.client.GetPlaylists(ctx)
 	if err != nil {
 		return fmt.Errorf("get playlists: %w", err)
 	}
 
 	existingIndex := slices.IndexFunc(playlists, func(item navidrome.Playlist) bool {
-		return strings.EqualFold(item.Name, name)
+		nameMatches := strings.EqualFold(item.Name, name)
+		ownerMatches := w.owner == "" || item.Owner == "" || strings.EqualFold(item.Owner, w.owner)
+		return nameMatches && ownerMatches
 	})
 
 	if existingIndex >= 0 {
@@ -62,12 +54,20 @@ func (w *Writer) Upsert(ctx context.Context, name string, tracks []model.Track) 
 				return fmt.Errorf("get playlist %q details: %w", name, countErr)
 			}
 		}
+		if removeCount == 0 && len(songIDs) == 0 {
+			w.logger.Printf("playlist %q is already empty", name)
+			return nil
+		}
 
 		if err := w.client.UpdatePlaylist(ctx, playlists[existingIndex].ID, removeCount, songIDs); err != nil {
 			return fmt.Errorf("update playlist %q: %w", name, err)
 		}
 
 		w.logger.Printf("updated playlist %q with %d tracks", name, len(songIDs))
+		return nil
+	}
+	if len(songIDs) == 0 {
+		w.logger.Printf("playlist %q has no tracks and does not exist, skipping create", name)
 		return nil
 	}
 

--- a/internal/playlist/writer_test.go
+++ b/internal/playlist/writer_test.go
@@ -1,0 +1,91 @@
+package playlist
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"go-navi-smart-playlist/internal/model"
+	"go-navi-smart-playlist/internal/navidrome"
+)
+
+type fakePlaylistClient struct {
+	playlists       []navidrome.Playlist
+	detailCount     int
+	createdName     string
+	createdIDs      []string
+	updatedID       string
+	updatedRemove   int
+	updatedSongIDs  []string
+	getDetailsCalls int
+}
+
+func (f *fakePlaylistClient) GetPlaylists(context.Context) ([]navidrome.Playlist, error) {
+	return f.playlists, nil
+}
+
+func (f *fakePlaylistClient) GetPlaylistSongCount(context.Context, string) (int, error) {
+	f.getDetailsCalls++
+	return f.detailCount, nil
+}
+
+func (f *fakePlaylistClient) CreatePlaylist(_ context.Context, name string, songIDs []string) error {
+	f.createdName = name
+	f.createdIDs = append([]string(nil), songIDs...)
+	return nil
+}
+
+func (f *fakePlaylistClient) UpdatePlaylist(_ context.Context, playlistID string, removeCount int, songIDs []string) error {
+	f.updatedID = playlistID
+	f.updatedRemove = removeCount
+	f.updatedSongIDs = append([]string(nil), songIDs...)
+	return nil
+}
+
+func TestWriterClearsExistingPlaylistWhenGenerationIsEmpty(t *testing.T) {
+	client := &fakePlaylistClient{
+		playlists: []navidrome.Playlist{{ID: "mine", Name: "Fresh & Unplayed", Owner: "alice", SongCount: 3}},
+	}
+	writer := NewWriter(client, log.New(testWriter{t}, "", 0), "alice")
+
+	if err := writer.Upsert(context.Background(), "Fresh & Unplayed", nil); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if client.updatedID != "mine" || client.updatedRemove != 3 || len(client.updatedSongIDs) != 0 {
+		t.Fatalf("expected playlist clear, got %+v", client)
+	}
+}
+
+func TestWriterDoesNotUpdateAnotherOwnersPublicPlaylist(t *testing.T) {
+	client := &fakePlaylistClient{
+		playlists: []navidrome.Playlist{{ID: "theirs", Name: "Deep Cuts", Owner: "bob", Public: true, SongCount: 4}},
+	}
+	writer := NewWriter(client, log.New(testWriter{t}, "", 0), "alice")
+
+	if err := writer.Upsert(context.Background(), "Deep Cuts", []model.Track{{ID: "song-1"}}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if client.updatedID != "" {
+		t.Fatalf("updated another user's playlist %q", client.updatedID)
+	}
+	if client.createdName != "Deep Cuts" || len(client.createdIDs) != 1 {
+		t.Fatalf("expected own playlist creation, got %+v", client)
+	}
+}
+
+func TestWriterPrefersMatchingOwner(t *testing.T) {
+	client := &fakePlaylistClient{
+		playlists: []navidrome.Playlist{
+			{ID: "theirs", Name: "Quick Mix", Owner: "bob", Public: true, SongCount: 4},
+			{ID: "mine", Name: "Quick Mix", Owner: "alice", SongCount: 2},
+		},
+	}
+	writer := NewWriter(client, log.New(testWriter{t}, "", 0), "alice")
+
+	if err := writer.Upsert(context.Background(), "Quick Mix", []model.Track{{ID: "song-1"}}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if client.updatedID != "mine" || client.updatedRemove != 2 {
+		t.Fatalf("expected own playlist update, got %+v", client)
+	}
+}

--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -16,9 +16,9 @@ func New(weights config.Weights) *Engine {
 }
 
 func (e *Engine) BaseScore(track features.TrackFeatures) float64 {
-	playCountTerm := math.Log(float64(track.Track.PlayCount) + 1)
+	playCountTerm := track.PlayCountPercentile
 	if track.Track.PlayCount == 0 {
-		playCountTerm += 0.35
+		playCountTerm = 0.15
 	}
 
 	recencyScore := math.Exp(-track.DaysSinceLastPlayed / e.weights.DecayDays)
@@ -31,6 +31,7 @@ func (e *Engine) BaseScore(track features.TrackFeatures) float64 {
 		0.7*track.NoveltyScore +
 		0.6*track.RecencyTrendScore +
 		0.3*track.StabilityScore +
+		0.2*track.ArtistAffinity +
 		0.25*ratingScore +
 		0.2*boolFloat(track.Track.Starred) -
 		0.75*track.RepeatFatigueScore -

--- a/internal/scoring/scoring_test.go
+++ b/internal/scoring/scoring_test.go
@@ -1,0 +1,23 @@
+package scoring
+
+import (
+	"testing"
+
+	"go-navi-smart-playlist/internal/config"
+	"go-navi-smart-playlist/internal/features"
+	"go-navi-smart-playlist/internal/model"
+)
+
+func TestBaseScoreUsesNormalizedPlayCount(t *testing.T) {
+	engine := New(config.Weights{PlayCount: 1, Recency: 1, Freshness: 1, DecayDays: 45})
+	base := features.TrackFeatures{PlayCountPercentile: 0.8, DaysSinceLastPlayed: 30, DaysSinceAdded: 300}
+
+	low := base
+	low.Track = model.Track{PlayCount: 10}
+	high := base
+	high.Track = model.Track{PlayCount: 1_000_000}
+
+	if engine.BaseScore(low) != engine.BaseScore(high) {
+		t.Fatalf("raw play count magnitude must not dominate normalized score")
+	}
+}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -38,6 +38,7 @@ type DerivedFeatureSnapshot struct {
 	RecencyTrend        float64   `json:"recencyTrend"`
 	RepeatFatigue       float64   `json:"repeatFatigue"`
 	ArtistSaturation    float64   `json:"artistSaturation"`
+	ArtistAffinity      float64   `json:"artistAffinity"`
 	AlbumSaturation     float64   `json:"albumSaturation"`
 	NoveltyScore        float64   `json:"noveltyScore"`
 	StabilityScore      float64   `json:"stabilityScore"`
@@ -113,16 +114,28 @@ func (s *Store) Save(payload *HistoryState) error {
 		return fmt.Errorf("create state directory: %w", err)
 	}
 
-	file, err := os.Create(s.path)
+	file, err := os.CreateTemp(filepath.Dir(s.path), "."+filepath.Base(s.path)+".tmp-*")
 	if err != nil {
-		return fmt.Errorf("create state file: %w", err)
+		return fmt.Errorf("create temporary state file: %w", err)
 	}
-	defer file.Close()
+	temporaryPath := file.Name()
+	defer os.Remove(temporaryPath)
 
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(payload); err != nil {
+		_ = file.Close()
 		return fmt.Errorf("encode state file: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("sync state file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close state file: %w", err)
+	}
+	if err := os.Rename(temporaryPath, s.path); err != nil {
+		return fmt.Errorf("replace state file: %w", err)
 	}
 
 	return nil

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"log"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,6 +48,43 @@ func TestLoadCorruptStateFallsBackToEmpty(t *testing.T) {
 	}
 	if len(output.Tracks) != 0 {
 		t.Fatalf("expected empty state on corrupt load, got %d tracks", len(output.Tracks))
+	}
+}
+
+func TestFailedSaveKeepsPreviousState(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "state.json")
+	store := NewStore(path, true, log.New(testWriter{t}, "", 0))
+
+	initial := NewHistoryState()
+	initial.Tracks["track-1"] = TrackSnapshot{ID: "track-1", PlayCount: 7}
+	if err := store.Save(initial); err != nil {
+		t.Fatalf("save initial state: %v", err)
+	}
+
+	invalid := NewHistoryState()
+	invalid.Tracks["bad"] = TrackSnapshot{
+		ID:      "bad",
+		Derived: DerivedFeatureSnapshot{Vector: []float64{math.NaN()}},
+	}
+	if err := store.Save(invalid); err == nil {
+		t.Fatalf("expected invalid state save to fail")
+	}
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("load previous state: %v", err)
+	}
+	if loaded.Tracks["track-1"].PlayCount != 7 {
+		t.Fatalf("previous state was replaced after failed save: %+v", loaded)
+	}
+
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatalf("read state directory: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "state.json" {
+		t.Fatalf("temporary state file not cleaned up: %+v", entries)
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace shared ranking behavior with playlist-specific eligibility, scoring, carryover, and deterministic weekly rotation
- add Fresh & Unplayed, Forgotten Favorites, Rising This Week, Deep Cuts, Quick Mix, and Longform
- exclude every source track from similarity playlists and use genre metadata when available
- normalize play-count influence and add artist-affinity scoring
- validate configuration strictly, write state atomically, clear stale empty playlists, and avoid updating another user owner playlist
- add test coverage and require formatting, vet, and race tests before publishing
- publish multi-platform AMD64 and ARM64 container images

## Operational note

DRY_RUN support is removed. Every service run writes generated playlists to Navidrome.

## Verification

- go test -race ./...
- go vet ./...
- staticcheck ./...
- formatting and diff checks
- YAML parse validation
- native Go build
- Linux AMD64 Docker build